### PR TITLE
Use ffi-napi for compatibility of Node 12+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var ffi = require('ffi');
+var ffi = require('ffi-napi');
 var path = require('path');
 
 var lib = ffi.Library(path.join(__dirname, './rust-dylib/libget_dir'), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,61 +1,107 @@
 {
-  "name": "get-node-modules",
+  "name": "get-node-modules-rust",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "ffi-napi": {
+      "version": "3.0.1",
+      "resolved": "https://npm.garenanow.com/ffi-napi/-/ffi-napi-3.0.1.tgz",
+      "integrity": "sha512-zOvTqC9pjXNfVUruk4phi+Itayg3yefgiR/CZtr09OcrYulBq9jeUtf/GvFeXfNRv8q2qu3+ijMPj4rewTWbVg==",
       "requires": {
-        "ms": "2.0.0"
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1",
+        "ref-struct-di": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://npm.garenanow.com/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://npm.garenanow.com/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
-    "ffi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ffi/-/ffi-2.3.0.tgz",
-      "integrity": "sha512-vkPA9Hf9CVuQ5HeMZykYvrZF2QNJ/iKGLkyDkisBnoOOFeFXZQhUPxBARPBIZMJVulvBI2R+jgofW03gyPpJcQ==",
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://npm.garenanow.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://npm.garenanow.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
       "requires": {
-        "bindings": "~1.2.0",
-        "debug": "2",
-        "nan": "2",
-        "ref": "1",
-        "ref-struct": "1"
+        "get-symbol-from-current-process-h": "^1.0.1"
       }
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    "node-addon-api": {
+      "version": "2.0.1",
+      "resolved": "https://npm.garenanow.com/node-addon-api/-/node-addon-api-2.0.1.tgz",
+      "integrity": "sha512-2WVfwRfIr1AVn3dRq4yRc2Hn35ND+mPJH6inC6bjpYCZVrpXPB4j3T6i//OGVfqVsR1t/X/axRulDsheq4F0LQ=="
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    "node-gyp-build": {
+      "version": "4.2.2",
+      "resolved": "https://npm.garenanow.com/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
     },
-    "ref": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ref/-/ref-1.3.5.tgz",
-      "integrity": "sha512-2cBCniTtxcGUjDpvFfVpw323a83/0RLSGJJY5l5lcomZWhYpU2cuLdsvYqMixvsdLJ9+sTdzEkju8J8ZHDM2nA==",
+    "ref-napi": {
+      "version": "2.0.3",
+      "resolved": "https://npm.garenanow.com/ref-napi/-/ref-napi-2.0.3.tgz",
+      "integrity": "sha512-zsAhPhh9gUlk0pP5iR9nhvwFeC/E9G1X0cdH/qQRTwx3VDgVi40Aflq/EdbobcVg++RNaMxZsbaQV+/E2u57LQ==",
       "requires": {
-        "bindings": "1",
-        "debug": "2",
-        "nan": "2"
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://npm.garenanow.com/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://npm.garenanow.com/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
-    "ref-struct": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ref-struct/-/ref-struct-1.1.0.tgz",
-      "integrity": "sha1-XV7mWtQc78Olxf60BYcmHkee3BM=",
+    "ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://npm.garenanow.com/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
       "requires": {
-        "debug": "2",
-        "ref": "1"
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://npm.garenanow.com/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://npm.garenanow.com/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "fast search node_modules dir, power by Rust dylib",
   "main": "index.js",
   "dependencies": {
-    "ffi": "^2.3.0"
+    "ffi-napi": "^3.0.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The package [`ffi`](https://www.npmjs.com/package/ffi) is not compatible with Node 12, so I change it to [`ffi-napi`](https://www.npmjs.com/package/ffi-napi). I tested it locally and it works well


Related to: https://github.com/chinanf-boy/node-modules-size/issues/4 